### PR TITLE
Add suspend functionality to GitOpsSet

### DIFF
--- a/api/v1alpha1/gitopsset_types.go
+++ b/api/v1alpha1/gitopsset_types.go
@@ -38,6 +38,11 @@ type GitOpsSetGenerator struct {
 
 // GitOpsSetSpec defines the desired state of GitOpsSet
 type GitOpsSetSpec struct {
+	// Suspend tells the controller to suspend the reconciliation of this
+	// GitOpsSet.
+	// +optional
+	Suspend bool `json:"suspend,omitempty"`
+
 	// Generators generate the data to be inserted into the provided templates.
 	Generators []GitOpsSetGenerator `json:"generators,omitempty"`
 

--- a/config/crd/bases/templates.weave.works_gitopssets.yaml
+++ b/config/crd/bases/templates.weave.works_gitopssets.yaml
@@ -87,6 +87,10 @@ spec:
                       type: object
                   type: object
                 type: array
+              suspend:
+                description: Suspend tells the controller to suspend the reconciliation
+                  of this GitOpsSet.
+                type: boolean
               templates:
                 description: Templates are a set of YAML templates that are rendered
                   into resources from the data supplied by the generators.

--- a/controllers/gitopsset_controller.go
+++ b/controllers/gitopsset_controller.go
@@ -70,6 +70,12 @@ func (r *GitOpsSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		return ctrl.Result{}, nil
 	}
 
+	// Skip reconciliation if the GitOpsSet is suspended.
+	if gitOpsSet.Spec.Suspend {
+		logger.Info("Reconciliation is suspended for this GitOpsSet")
+		return ctrl.Result{}, nil
+	}
+
 	inventory, err := r.reconcileResources(ctx, &gitOpsSet)
 	if err != nil {
 		templatesv1.SetGitOpsSetReadiness(&gitOpsSet, metav1.ConditionFalse, templatesv1.ReconciliationFailedReason, err.Error())


### PR DESCRIPTION
As per the Flux convention, 'spec.suspend' configures the GitOpsSet to not reconcile the resources.