### PR TITLE
Add forks to pullrequest generator and template params

### DIFF
--- a/api/v1alpha1/gitopsset_types.go
+++ b/api/v1alpha1/gitopsset_types.go
@@ -50,6 +50,11 @@ type PullRequestGenerator struct {
 	// This may be applied on the server.
 	// +optional
 	Labels []string `json:"labels,omitempty"`
+
+	// Fork is used to filter out forks from the target PRs if false,
+	// or to include forks if  true
+	// +optional
+	Forks bool `json:"forks,omitempty"`
 }
 
 // GitRepositoryGeneratorFileItemm defines a path to a file to be parsed when generating.

--- a/config/crd/bases/templates.weave.works_gitopssets.yaml
+++ b/config/crd/bases/templates.weave.works_gitopssets.yaml
@@ -144,6 +144,11 @@ spec:
                                     - gitlab
                                     - bitbucketserver
                                     type: string
+                                  forks:
+                                    description: Fork is used to filter out forks
+                                      from the target PRs if false, or to include
+                                      forks if  true
+                                    type: boolean
                                   interval:
                                     description: The interval at which to check for
                                       repository updates.
@@ -195,6 +200,10 @@ spec:
                           - gitlab
                           - bitbucketserver
                           type: string
+                        forks:
+                          description: Fork is used to filter out forks from the target
+                            PRs if false, or to include forks if  true
+                          type: boolean
                         interval:
                           description: The interval at which to check for repository
                             updates.

--- a/controllers/templates/generators/pullrequests/pull_requests.go
+++ b/controllers/templates/generators/pullrequests/pull_requests.go
@@ -92,8 +92,13 @@ func (g *PullRequestGenerator) Generate(ctx context.Context, sg *templatesv1.Git
 			continue
 		}
 
+		// if Forks flag is set to false, and repo is a fork, don't include it
+		isFork := sg.PullRequests.Repo != pr.Fork
+		if !sg.PullRequests.Forks && isFork {
+			continue
+		}
 		// TODO: This should provide additional fields, including the
-		// destination branch, whether or not the result is from a fork etc.
+		// destination branch ...etc.
 		// It should also sanitise the branches, for example, a branch can
 		// contain a `/` or do we delegate this to the `sanitize` function in
 		// the template rendering?
@@ -103,6 +108,7 @@ func (g *PullRequestGenerator) Generate(ctx context.Context, sg *templatesv1.Git
 			"head_sha":      pr.Head.Sha,
 			"clone_url":     pr.Head.Repo.Clone,
 			"clone_ssh_url": pr.Head.Repo.CloneSSH,
+			"fork":          isFork,
 		})
 	}
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -233,6 +233,8 @@ For non-public installations, you can configure the `serverURL` field and point 
 
 The `driver` field can be `github` or `gitlab` or `bitbucketserver`, other options can be supported from [go-scm](https://github.com/jenkins-x/go-scm/blob/main/scm/factory/factory.go).
 
+The `forks` flag field can be used to indicate whether to include forks in the target pull requests or not. If set to `true` any pull request from a fork repository will be included, otherwise if `false` or not indicated the pull requests from fork repositories are discarded.
+
 Additionally labels can be provided for querying pull requests with matching labels e.g.
 ```yaml
 - pullRequests:
@@ -241,6 +243,7 @@ Additionally labels can be provided for querying pull requests with matching lab
     repo: bigkevmcd/go-demo
     secretRef:
       name: github-secret
+    forks: false
     labels:
       - deploy
 ```
@@ -252,6 +255,7 @@ The fields emitted by the pull-request are as follows:
  * `head_sha` this is the SHA of the commit in the merge branch
  * `clone_url` this is the HTTPS clone URL for this repository
  * `clone_ssh_url` this is the SSH clone URL for this repository
+ * `fork` this indicates whether the pull request is from a fork (true) or not (false)
 
 You will need an API key that can query the GitHub API.
 ```shell

--- a/examples/pull-requests/pull-requests-generator.yaml
+++ b/examples/pull-requests/pull-requests-generator.yaml
@@ -16,6 +16,7 @@ spec:
         repo: bigkevmcd/go-demo
         secretRef:
           name: github-secret
+        forks: false
   templates:
     - content:
         apiVersion: source.toolkit.fluxcd.io/v1beta2


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes https://github.com/weaveworks/weave-gitops-enterprise/issues/2309


<!--
Describe what has changed in this PR.
For UI changes also include a screenshot.
-->
**What changed?**
- Add `forks` flag to pull request generator which indicates whether to include forks in the pull requests found
- Add `fork` bool in template params which indicates whether the pull request is a fork or not

*note*: A pull request is detected as a fork if the fork field (string) indicating the repo is different than the target repository

<!-- Tell your future self why have you made these changes -->
**Why was this change made?**
- To optionally include and exclude forks when using the pull request generator, defaulting to false
-  fork boolean in the template params is added to differentiate between forks and pull requests from the original target repo 



<!--
How have you verified this change/product value? Tested locally?
Added integration/acceptance test(s)?
Unit tests are required.
-->
**How did you validate the change?**
unit tests and manual test

