### PR TITLE
Add shortName alias for GitOpsSets

### DIFF
--- a/api/v1alpha1/gitopsset_types.go
+++ b/api/v1alpha1/gitopsset_types.go
@@ -129,6 +129,7 @@ type GitOpsSetStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+//+kubebuilder:resource:shortName="gs"
 //+kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description=""
 //+kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type==\"Ready\")].status",description=""
 //+kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.conditions[?(@.type==\"Ready\")].message",description=""

--- a/config/crd/bases/templates.weave.works_gitopssets.yaml
+++ b/config/crd/bases/templates.weave.works_gitopssets.yaml
@@ -12,6 +12,8 @@ spec:
     kind: GitOpsSet
     listKind: GitOpsSetList
     plural: gitopssets
+    shortNames:
+    - gs
     singular: gitopsset
   scope: Namespaced
   versions:


### PR DESCRIPTION
This configures the shortName to be gs which means that you can do `kubectl get gs`.

`gss` might be more mnemonic (or might not).