### PR TITLE
Error when no key for value available.

### DIFF
--- a/controllers/templates/renderer.go
+++ b/controllers/templates/renderer.go
@@ -52,9 +52,9 @@ func Render(ctx context.Context, r *templatesv1.GitOpsSet, configuredGenerators 
 	return rendered, nil
 }
 
-func repeat(tmpl templatesv1.GitOpsSetTemplate, params map[string]any) ([]any, error) {
+func repeat(tmpl templatesv1.GitOpsSetTemplate, params map[string]any) ([]map[string]any, error) {
 	if tmpl.Repeat == "" {
-		return []any{
+		return []map[string]any{
 			map[string]any{
 				"Element": params,
 			},
@@ -84,7 +84,7 @@ func repeat(tmpl templatesv1.GitOpsSetTemplate, params map[string]any) ([]any, e
 		}
 	}
 
-	elements := []any{}
+	elements := []map[string]any{}
 	for _, v := range repeated {
 		elements = append(elements, map[string]any{
 			"Element": params,
@@ -155,7 +155,7 @@ func renderTemplateParams(tmpl templatesv1.GitOpsSetTemplate, params map[string]
 	return objects, nil
 }
 
-func render(name types.NamespacedName, b []byte, params any) ([]byte, error) {
+func render(name types.NamespacedName, b []byte, params map[string]any) ([]byte, error) {
 	t, err := template.New(fmt.Sprintf("%s", name)).
 		Option("missingkey=error").
 		Funcs(templateFuncs).Parse(string(b))
@@ -197,6 +197,13 @@ func makeTemplateFunctions() template.FuncMap {
 	}
 
 	f["sanitize"] = sanitize.SanitizeDNSName
+	f["getordefault"] = func(element map[string]any, key string, def interface{}) interface{} {
+		if v, ok := element[key]; ok {
+			return v
+		}
+
+		return def
+	}
 
 	return f
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -357,6 +357,56 @@ spec:
             name: go-demo-repo
 ```
 
+## Templating functions
+
+Currently, the [Sprig](http://masterminds.github.io/sprig/) functions are available in the templating, with some functions removed[^sprig] for security reasons.
+
+In addition, we also provide two additional functions:
+
+ * sanitize - sanitises strings to be compatible with [Kubernetes DNS](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names) name requirements
+ * getordefault - gets a key from the `.Element` or defaults to another value.
+
+The examples below assume an element that looks like this:
+```json
+{
+  "team": "engineering dev"
+}
+```
+
+### sanitize template function
+
+And a template that looks like this:
+```yaml
+kind: Service
+metadata:
+  name: {{ sanitize .Element.team }}-demo
+```
+
+This would output:
+```yaml
+kind: Service
+metadata:
+  name: engineeringdev-demo
+```
+
+### getordefault
+
+For template that looks like this:
+```yaml
+kind: Service
+metadata:
+  name: {{ getordefault .Element "name" "defaulted" }}-demo
+```
+
+This would output:
+```yaml
+kind: Service
+metadata:
+  name: defaulted-demo
+```
+
+If the _key_ to get does exist in the `.Element` it will be inserted, the "default" is only inserted if it doesn't exist.
+
 ## Security
 
 **WARNING** generating resources and applying them directly into your cluster can be dangerous to the health of your cluster.
@@ -408,3 +458,4 @@ spec:
 ```
 
 [^yaml]: These are written as YAML mappings
+[^sprig]: The following functions are removed "env", "expandenv", "getHostByName", "genPrivateKey", "derivePassword", "sha256sum", "base", "dir", "ext", "clean", "isAbs", "osBase", "osDir", "osExt", "osClean", "osIsAbs"


### PR DESCRIPTION
By default we get `<no value>` inserted, this isn't particularly useful when generating YAML as it makes it invalid.

This changes this to fail when an attempt to use an undefined key is made.

It also threads the name of the GitOpsSet as the template name so that errors come from the correct resource.