### PR TITLE
Add performance metrics to controller

### DIFF
--- a/api/v1alpha1/gitopsset_types.go
+++ b/api/v1alpha1/gitopsset_types.go
@@ -170,12 +170,6 @@ func (in *GitOpsSet) SetConditions(conditions []metav1.Condition) {
 	in.Status.Conditions = conditions
 }
 
-// GetStatusConditions returns a pointer to the Status.Conditions slice.
-// Deprecated: use GetConditions instead.
-func (in *GitOpsSet) GetStatusConditions() *[]metav1.Condition {
-	return &in.Status.Conditions
-}
-
 //+kubebuilder:object:root=true
 
 // GitOpsSetList contains a list of GitOpsSet

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -24,9 +24,6 @@ metadata:
     app.kubernetes.io/created-by: gitopssets-controller
     app.kubernetes.io/part-of: gitopssets-controller
     app.kubernetes.io/managed-by: kustomize
-  annotations:
-    prometheus.io/scrape: "true"
-    prometheus.io/port: "8080"
 spec:
   selector:
     matchLabels:

--- a/main.go
+++ b/main.go
@@ -18,6 +18,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 
+	sourcev1 "github.com/fluxcd/source-controller/api/v1beta2"
+	clustersv1 "github.com/weaveworks/cluster-controller/api/v1alpha1"
 	templatesv1alpha1 "github.com/weaveworks/gitopssets-controller/api/v1alpha1"
 	"github.com/weaveworks/gitopssets-controller/controllers"
 	"github.com/weaveworks/gitopssets-controller/controllers/templates/generators"
@@ -26,10 +28,6 @@ import (
 	"github.com/weaveworks/gitopssets-controller/controllers/templates/generators/list"
 	"github.com/weaveworks/gitopssets-controller/controllers/templates/generators/matrix"
 	"github.com/weaveworks/gitopssets-controller/controllers/templates/generators/pullrequests"
-
-	clustersv1 "github.com/weaveworks/cluster-controller/api/v1alpha1"
-
-	sourcev1 "github.com/fluxcd/source-controller/api/v1beta2"
 	//+kubebuilder:scaffold:imports
 )
 
@@ -57,11 +55,9 @@ func main() {
 		defaultServiceAccount string
 		clientOptions         runtimeclient.Options
 		logOptions            logger.Options
-		eventsAddr            string
 	)
 
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
-	flag.StringVar(&eventsAddr, "events-addr", "", "The address of the events receiver.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
@@ -133,7 +129,6 @@ func main() {
 			"Cluster":      cluster.GeneratorFactory,
 		},
 		Metrics: metricsH,
-		// EventRecorder: eventRecorder,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", controllerName)
 		os.Exit(1)


### PR DESCRIPTION
<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes https://github.com/weaveworks/weave-gitops-enterprise/issues/2358

<!--
Describe what has changed in this PR.
For UI changes also include a screenshot.
-->
**What changed?**
Record prometheus metrics (readiness,duration, and suspend) 

<!-- Tell your future self why have you made these changes -->
**Why was this change made?**
To help with debugging when there are issues
<!--
Explain to your reviewers the key implementation points, including why you made
certain choices in favour of others. Highlight key areas of the code which need
extra attention, and also indicate which parts are less relevant (eg renaming,
refactoring, etc
-->
**How was this change implemented?**
Metrics are recorded in the controller reconcile process using using https://pkg.go.dev/github.com/fluxcd/pkg/runtime/controller#Metrics
<!--
How have you verified this change/product value? Tested locally?
Added integration/acceptance test(s)?
Unit tests are required.
-->
**How did you validate the change?**
manual test , run local prometheus and query metrics
![Screenshot from 2023-02-26 22-03-03](https://user-images.githubusercontent.com/17128393/221434277-e0ef90a1-b152-4fa8-9e6c-bfd14823acd5.png)

