### PR TITLE
Implement optional list expansion.

### DIFF
--- a/api/v1alpha1/gitopsset_types.go
+++ b/api/v1alpha1/gitopsset_types.go
@@ -106,6 +106,16 @@ type APIClientGenerator struct {
 	// If set, this will configure the Method to be POST automatically.
 	// +optional
 	Body *apiextensionsv1.JSON `json:"body,omitempty"`
+
+	// SingleElement means generate a single element with the result of the API
+	// call.
+	//
+	// When true, the response must be a JSON object and will be returned as a
+	// single element, i.e. only one element will be generated containing the
+	// entire object.
+	//
+	// +optional
+	SingleElement bool `json:"singleElement,omitempty"`
 }
 
 // HeadersReference references either a Secret or ConfigMap to be used for

--- a/config/crd/bases/templates.weave.works_gitopssets.yaml
+++ b/config/crd/bases/templates.weave.works_gitopssets.yaml
@@ -103,6 +103,13 @@ spec:
                           - GET
                           - POST
                           type: string
+                        singleElement:
+                          description: "SingleElement means generate a single element
+                            with the result of the API call. \n When true, the response
+                            must be a JSON object and will be returned as a single
+                            element, i.e. only one element will be generated containing
+                            the entire object."
+                          type: boolean
                       required:
                       - interval
                       type: object
@@ -273,6 +280,14 @@ spec:
                                     - GET
                                     - POST
                                     type: string
+                                  singleElement:
+                                    description: "SingleElement means generate a single
+                                      element with the result of the API call. \n
+                                      When true, the response must be a JSON object
+                                      and will be returned as a single element, i.e.
+                                      only one element will be generated containing
+                                      the entire object."
+                                    type: boolean
                                 required:
                                 - interval
                                 type: object

--- a/controllers/templates/generators/apiclient/api_client.go
+++ b/controllers/templates/generators/apiclient/api_client.go
@@ -82,6 +82,9 @@ func (g *APIClientGenerator) Generate(ctx context.Context, sg *templatesv1.GitOp
 	}
 
 	if sg.APIClient.JSONPath == "" {
+		if sg.APIClient.SingleElement {
+			return g.generateFromResponseBodySingleElement(body, sg.APIClient.Endpoint)
+		}
 		return g.generateFromResponseBody(body, sg.APIClient.Endpoint)
 	}
 
@@ -141,6 +144,16 @@ func (g *APIClientGenerator) generateFromResponseBody(body []byte, endpoint stri
 	}
 
 	return res, nil
+}
+
+func (g *APIClientGenerator) generateFromResponseBodySingleElement(body []byte, endpoint string) ([]map[string]any, error) {
+	var result map[string]any
+	if err := json.Unmarshal(body, &result); err != nil {
+		g.Logger.Error(err, "failed to unmarshal JSON response", "endpoint", endpoint)
+		return nil, fmt.Errorf("failed to unmarshal JSON response from endpoint %s", endpoint)
+	}
+
+	return []map[string]any{result}, nil
 }
 
 func (g *APIClientGenerator) generateFromJSONPath(body []byte, endpoint, jsonPath string) ([]map[string]any, error) {

--- a/controllers/templates/generators/apiclient/api_client_test.go
+++ b/controllers/templates/generators/apiclient/api_client_test.go
@@ -73,6 +73,22 @@ func TestGenerate(t *testing.T) {
 			},
 		},
 		{
+			name: "simple API endpoint with expandList false",
+			apiClient: &templatesv1.APIClientGenerator{
+				Endpoint:      ts.URL + "/api/non-array",
+				Method:        http.MethodGet,
+				SingleElement: true,
+			},
+			want: []map[string]any{
+				{
+					"things": []any{
+						map[string]any{"name": "testing1"},
+						map[string]any{"name": "testing2"},
+					},
+				},
+			},
+		},
+		{
 			name: "simple API endpoint with post request",
 			apiClient: &templatesv1.APIClientGenerator{
 				Endpoint: ts.URL + "/api/post-testing",

--- a/docs/README.md
+++ b/docs/README.md
@@ -510,8 +510,7 @@ stringData:
 ```
 The keys in the secret match the command-line example using curl.
 
-Unlike the Pull Request generator, you need to figure out the paths to the
-elements yourself.
+Unlike the Pull Request generator, you need to figure out the paths to the elements yourself.
 
 #### APIClient JSONPath
 
@@ -587,6 +586,32 @@ The JSON body sent will look like this:
 ```json
 {"name":"testing","value":"testing2"}
 ```
+
+#### APIClient simple results
+
+Instead of using the JSONPath to extract from a complex structure, you can configure the result to be a single element.
+
+```yaml
+apiVersion: templates.weave.works/v1alpha1
+kind: GitOpsSet
+metadata:
+  labels:
+    app.kubernetes.io/name: gitopsset
+    app.kubernetes.io/instance: gitopsset-sample
+    app.kubernetes.io/part-of: gitopssets-controller
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/created-by: gitopssets-controller
+  name: api-client-sample
+spec:
+  generators:
+    - apiClient:
+        singleElement: true
+        interval: 5m
+        endpoint: https://api.example.com/demo
+```
+Whatever result is parsed from the API endpoint will be returned as a map in a single element.
+
+For generation, you might need to use the `repeat` mechanism to generate repeating results.
 
 ## Templating functions
 


### PR DESCRIPTION
This allows the apiClient generator to optionally generate a single element with the entire body of the response.

Combined with the repeat functionality, this allows for a set of resources to be generated from any response.