### PR TITLE
Implement custom delimiters.

### DIFF
--- a/controllers/templates/renderer.go
+++ b/controllers/templates/renderer.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"strings"
 	"text/template"
 
 	"github.com/Masterminds/sprig/v3"
@@ -20,6 +21,14 @@ import (
 	templatesv1 "github.com/weaveworks/gitopssets-controller/api/v1alpha1"
 	"github.com/weaveworks/gitopssets-controller/controllers/templates/generators"
 )
+
+// TemplateDelimiterAnnotation can be added to a Template to change the Go
+// template delimiter.
+//
+// It's assumed to be a string with "left,right"
+// By default the delimiters are the standard Go templating delimiters:
+// {{ and }}.
+const TemplateDelimiterAnnotation string = "templates.weave.works/delimiters"
 
 var templateFuncs template.FuncMap = makeTemplateFunctions()
 
@@ -38,7 +47,7 @@ func Render(ctx context.Context, r *templatesv1.GitOpsSet, configuredGenerators 
 			for _, param := range params {
 				for _, template := range r.Spec.Templates {
 					namespacedName := types.NamespacedName{Name: r.GetName(), Namespace: r.GetNamespace()}
-					res, err := renderTemplateParams(template, param, namespacedName)
+					res, err := renderTemplateParams(*r, template, param, namespacedName)
 					if err != nil {
 						return nil, fmt.Errorf("failed to render template params for set %s: %w", r.GetName(), err)
 					}
@@ -95,7 +104,7 @@ func repeat(tmpl templatesv1.GitOpsSetTemplate, params map[string]any) ([]map[st
 	return elements, nil
 }
 
-func renderTemplateParams(tmpl templatesv1.GitOpsSetTemplate, params map[string]any, name types.NamespacedName) ([]*unstructured.Unstructured, error) {
+func renderTemplateParams(set templatesv1.GitOpsSet, tmpl templatesv1.GitOpsSetTemplate, params map[string]any, name types.NamespacedName) ([]*unstructured.Unstructured, error) {
 	var objects []*unstructured.Unstructured
 
 	repeatedParams, err := repeat(tmpl, params)
@@ -104,7 +113,7 @@ func renderTemplateParams(tmpl templatesv1.GitOpsSetTemplate, params map[string]
 	}
 
 	for _, p := range repeatedParams {
-		rendered, err := render(name, tmpl.Content.Raw, p)
+		rendered, err := render(set, name, tmpl.Content.Raw, p)
 		if err != nil {
 			return nil, err
 		}
@@ -155,9 +164,10 @@ func renderTemplateParams(tmpl templatesv1.GitOpsSetTemplate, params map[string]
 	return objects, nil
 }
 
-func render(name types.NamespacedName, b []byte, params map[string]any) ([]byte, error) {
+func render(set templatesv1.GitOpsSet, name types.NamespacedName, b []byte, params map[string]any) ([]byte, error) {
 	t, err := template.New(fmt.Sprintf("%s", name)).
 		Option("missingkey=error").
+		Delims(templateDelims(set)).
 		Funcs(templateFuncs).Parse(string(b))
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse template: %w", err)
@@ -206,4 +216,22 @@ func makeTemplateFunctions() template.FuncMap {
 	}
 
 	return f
+}
+
+func getOrDefault(element map[string]any, key string, def interface{}) interface{} {
+	if v, ok := element[key]; ok {
+		return v
+	}
+
+	return def
+}
+
+func templateDelims(gs templatesv1.GitOpsSet) (string, string) {
+	ann, ok := gs.GetAnnotations()[TemplateDelimiterAnnotation]
+	if ok {
+		if elems := strings.Split(ann, ","); len(elems) == 2 {
+			return elems[0], elems[1]
+		}
+	}
+	return "{{", "}}"
 }

--- a/controllers/templates/renderer_test.go
+++ b/controllers/templates/renderer_test.go
@@ -81,6 +81,37 @@ func TestRender(t *testing.T) {
 			},
 		},
 		{
+			name: "custom delimiters",
+			elements: []apiextensionsv1.JSON{
+				{Raw: []byte(`{"env": "engineering","externalIP": "192.168.50.50"}`)},
+			},
+			setOptions: []func(*templatesv1.GitOpsSet){
+				func(s *templatesv1.GitOpsSet) {
+					s.ObjectMeta.Annotations = map[string]string{
+						"templates.weave.works/delimiters": "$[,]",
+					}
+					s.Spec.Templates = []templatesv1.GitOpsSetTemplate{
+						{
+							Content: runtime.RawExtension{
+								Raw: mustMarshalJSON(t, makeTestService(types.NamespacedName{Name: "$[ .Element.env ]-demo"}, func(s *corev1.Service) {
+									s.ObjectMeta.Annotations = map[string]string{
+										"app.kubernetes.io/instance": "$[ .Element.env ]",
+									}
+									s.Spec.ClusterIP = "$[ .Element.externalIP ]"
+								})),
+							},
+						},
+					}
+				},
+			},
+			want: []*unstructured.Unstructured{
+				test.ToUnstructured(t, makeTestService(nsn("demo", "engineering-demo"),
+					setClusterIP("192.168.50.50"),
+					addAnnotations(map[string]string{"app.kubernetes.io/instance": string("engineering")}),
+					addLabels(map[string]string{"templates.weave.works/name": string("test-gitops-set"), "templates.weave.works/namespace": string("demo")}))),
+			},
+		},
+		{
 			name: "multiple templates yields cartesian result",
 			elements: []apiextensionsv1.JSON{
 				{Raw: []byte(`{"env": "engineering-dev","externalIP": "192.168.50.50"}`)},


### PR DESCRIPTION
Support for annotation "templates.weave.works/delimiters" on a GitOpsSet with a parseable string with custom delimiters.

e.g.
```
annotations:
  templates.weave.works/delimiters: "$[,]"
```
Gives `$[` and `]` as the delimiters in the template.