### PR TITLE
Fix test flake due to expecting exactly one event

### DIFF
--- a/tests/e2e/gitopsset_controller_test.go
+++ b/tests/e2e/gitopsset_controller_test.go
@@ -253,19 +253,16 @@ func TestEventsWithReconciling(t *testing.T) {
 	defer cleanupResource(t, testEnv, gs)
 	defer deleteAllKustomizations(t, testEnv)
 
+	want := &test.EventData{
+		EventType: "Normal",
+		Reason:    "ReconciliationSucceeded",
+	}
+	compareWant := gomega.BeComparableTo(want, cmpopts.IgnoreFields(test.EventData{}, "Message"))
+
 	g := gomega.NewWithT(t)
-	g.Eventually(func() bool {
-		want := []*test.EventData{
-			{
-				EventType: "Normal",
-				Reason:    "ReconciliationSucceeded",
-			},
-		}
-
-		return cmp.Diff(want, eventRecorder.Events, cmpopts.IgnoreFields(test.EventData{}, "Message")) == ""
-
-	}, timeout).Should(gomega.BeTrue())
-
+	g.Eventually(func() []*test.EventData {
+		return eventRecorder.Events
+	}, timeout).Should(gomega.ContainElement(compareWant))
 }
 
 func TestEventsWithFailingReconciling(t *testing.T) {


### PR DESCRIPTION
The test TestEventsWithReconciling checks that a resource has an event indicating a successful reconciliation, when reconciliation succeeds. It can be flakey, though, because it asserts the value of the whole list of events, and the controller can post multiple events before it gets checked.

So, instead: check that the list of events _contains_ an event indicating success.