### PR TITLE
Improve Repeat map handling.

### DIFF
--- a/controllers/templates/renderer.go
+++ b/controllers/templates/renderer.go
@@ -82,14 +82,14 @@ func repeat(tmpl templatesv1.GitOpsSetTemplate, params map[string]any) ([]map[st
 		return nil, fmt.Errorf("failed to find results from expression %q: %w", tmpl.Repeat, err)
 	}
 
-	repeated := []any{}
+	var repeated []any
 	for _, result := range results {
 		for _, v := range result {
 			slice, ok := v.Interface().([]any)
 			if ok {
 				repeated = append(repeated, slice...)
 			} else {
-				repeated = append(repeated, v)
+				repeated = append(repeated, v.Interface())
 			}
 		}
 	}

--- a/controllers/templates/renderer_test.go
+++ b/controllers/templates/renderer_test.go
@@ -201,6 +201,27 @@ func TestRender(t *testing.T) {
 			},
 		},
 		{
+			name: "repeat elements with maps",
+			elements: []apiextensionsv1.JSON{
+				{Raw: []byte(`{"wge":{"mgmt-repo":"example-repo","gui":false},"template":{"name":"dynamic-v1","namespace":"default"},"aws":{"region":"us-west-2"},"vpcs":[{"name":"v1","mode":"create","cidr":"10.0.0.0/16","publicsubnets":3,"privatesubnets":3}],"clusters":[{"name":"nested-cluster","mode":"create","gui":true,"vpc_name":"v1","version":1.23,"apps":[{"name":"example","version":"0.0.4"},{"name":"testing"}]}]}`)},
+			},
+			setOptions: []func(*templatesv1.GitOpsSet){
+				func(s *templatesv1.GitOpsSet) {
+					s.Spec.Templates = []templatesv1.GitOpsSetTemplate{
+						{
+							Repeat: "{ $.clusters[?(@.gui)] }",
+							Content: runtime.RawExtension{
+								Raw: mustMarshalJSON(t, makeTestNamespace("{{ .Repeat.name }}")),
+							},
+						},
+					}
+				},
+			},
+			want: []*unstructured.Unstructured{
+				test.ToUnstructured(t, makeTestNamespace("nested-cluster")),
+			},
+		},
+		{
 			name: "template with labels merged with default labels",
 			elements: []apiextensionsv1.JSON{
 				{Raw: []byte(`{"env": "engineering-dev","externalIP": "192.168.50.50"}`)},


### PR DESCRIPTION
This alters the Repeat processing when rendering templates to support map structures.

When the result of a Repeat JSONPath is a slice of objects then it will be added to the list as a map, which means that Repeat.<element> will work.