### PR TITLE
Update on changes to Matrix ImagePolicies

### DIFF
--- a/controllers/gitopsset_controller.go
+++ b/controllers/gitopsset_controller.go
@@ -519,6 +519,14 @@ func indexImagePolicies(o client.Object) []string {
 	for _, gen := range ks.Spec.Generators {
 		if gen.ImagePolicy != nil {
 			referencedPolicies = append(referencedPolicies, gen.ImagePolicy)
+			continue
+		}
+		if gen.Matrix != nil && gen.Matrix.Generators != nil {
+			for _, matrixGen := range gen.Matrix.Generators {
+				if matrixGen.ImagePolicy != nil {
+					referencedPolicies = append(referencedPolicies, matrixGen.ImagePolicy)
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
This updates the indexer to include ImagePolicies that are in Matrix elements.

This means that updates will trigger when an ImagePolicy inside a Matrix is changed.