### PR TITLE
Support multidoc when rendering the CLI

### DIFF
--- a/pkg/cmd/command_test.go
+++ b/pkg/cmd/command_test.go
@@ -40,3 +40,55 @@ spec:
 		t.Fatalf("failed to generate:\n%s", diff)
 	}
 }
+
+func TestRenderGitOpsSet_with_multiple_sets(t *testing.T) {
+	var out strings.Builder
+
+	err := renderGitOpsSet("testdata/list_sets.yaml", setup.DefaultGenerators, true, &out)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := `---
+apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+kind: Kustomization
+metadata:
+  labels:
+    app.kubernetes.io/instance: dev
+    app.kubernetes.io/name: go-demo
+    com.example/team: dev-team
+    templates.weave.works/name: gitopsset-sample
+    templates.weave.works/namespace: ""
+  name: dev-demo
+  namespace: default
+spec:
+  interval: 5m
+  path: ./examples/kustomize/environments/dev
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: go-demo-repo
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+kind: Kustomization
+metadata:
+  labels:
+    app.kubernetes.io/instance: dev
+    app.kubernetes.io/name: go-demo
+    com.example/team: dev-team
+    templates.weave.works/name: second-gitopsset-sample
+    templates.weave.works/namespace: ""
+  name: dev-demo-2
+  namespace: default
+spec:
+  interval: 5m
+  path: ./examples/kustomize/environments/dev
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: go-demo-repo
+`
+	if diff := cmp.Diff(want, out.String()); diff != "" {
+		t.Fatalf("failed to generate:\n%s", diff)
+	}
+}

--- a/pkg/cmd/testdata/list_sets.yaml
+++ b/pkg/cmd/testdata/list_sets.yaml
@@ -1,0 +1,71 @@
+---
+apiVersion: templates.weave.works/v1alpha1
+kind: GitOpsSet
+metadata:
+  labels:
+    app.kubernetes.io/name: gitopsset
+    app.kubernetes.io/instance: gitopsset-sample
+    app.kubernetes.io/part-of: gitopssets-controller
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/created-by: gitopssets-controller
+  name: gitopsset-sample
+spec:
+  generators:
+    - list:
+        elements:
+          - env: dev
+            team: dev-team
+  templates:
+    - content:
+        kind: Kustomization
+        apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+        metadata:
+          name: "{{ .Element.env }}-demo"
+          namespace: default
+          labels:
+            app.kubernetes.io/name: go-demo
+            app.kubernetes.io/instance: "{{ .Element.env }}"
+            com.example/team: "{{ .Element.team }}"
+        spec:
+          interval: 5m
+          path: "./examples/kustomize/environments/{{ .Element.env }}"
+          prune: true
+          sourceRef:
+            kind: GitRepository
+            name: go-demo-repo
+---
+apiVersion: templates.weave.works/v1alpha1
+kind: GitOpsSet
+metadata:
+  labels:
+    app.kubernetes.io/name: gitopsset
+    app.kubernetes.io/instance: gitopsset-sample
+    app.kubernetes.io/part-of: gitopssets-controller
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/created-by: gitopssets-controller
+  name: second-gitopsset-sample
+spec:
+  generators:
+    - list:
+        elements:
+          - env: dev
+            team: dev-team
+  templates:
+    - content:
+        kind: Kustomization
+        apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+        metadata:
+          name: "{{ .Element.env }}-demo-2"
+          namespace: default
+          labels:
+            app.kubernetes.io/name: go-demo
+            app.kubernetes.io/instance: "{{ .Element.env }}"
+            com.example/team: "{{ .Element.team }}"
+        spec:
+          interval: 5m
+          path: "./examples/kustomize/environments/{{ .Element.env }}"
+          prune: true
+          sourceRef:
+            kind: GitRepository
+            name: go-demo-repo
+---


### PR DESCRIPTION
When rendering a template from the CLI, all GitOpsSets in the YAML are rendered, splitting on the YAML multi-doc indicator.