### PR TITLE
enable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    reviewers:
+      - "weaveworks/pesto"


### PR DESCRIPTION
Part of https://github.com/weaveworks/corp/issues/3627 

As part of our switch to [Dependabot](https://github.com/weaveworks/corp/issues/3627 ) we have enabled it in the repo.It gives us vulnerability detection and remediation however PRs are not assigned so could be missed. 

This PR adds a baseline configuration file for Dependabot to setup both interval to daily (as starting point) and reviewers to pesto (as gitopsset owners). 

@weaveworks/pesto in case you think you are not the right maintainers group for this repo please add it to the PR. Otherwise please review it. 