### PR TITLE
Handle empty artifacts in directory processing.

### DIFF
--- a/controllers/templates/generators/gitrepository/git_repository_test.go
+++ b/controllers/templates/generators/gitrepository/git_repository_test.go
@@ -161,6 +161,17 @@ func TestGenerate_errors(t *testing.T) {
 			objects: []runtime.Object{test.NewGitRepository()},
 			wantErr: "no artifact for GitRepository default/test-repository",
 		},
+		{
+			name: "no artifact in GitRepository with dirs",
+			generator: &templatesv1.GitRepositoryGenerator{
+				RepositoryRef: "test-repository",
+				Directories: []templatesv1.RepositoryGeneratorDirectoryItem{
+					{Path: "applications/*"},
+				},
+			},
+			objects: []runtime.Object{test.NewGitRepository()},
+			wantErr: "no artifact for GitRepository default/test-repository",
+		},
 	}
 
 	for _, tt := range testCases {

--- a/controllers/templates/generators/ocirepository/oci_repository_test.go
+++ b/controllers/templates/generators/ocirepository/oci_repository_test.go
@@ -161,6 +161,17 @@ func TestGenerate_errors(t *testing.T) {
 			objects: []runtime.Object{newOCIRepository()},
 			wantErr: "no artifact for OCIRepository default/test-repository",
 		},
+		{
+			name: "no artifact in OCIRepository with dirs",
+			generator: &templatesv1.OCIRepositoryGenerator{
+				RepositoryRef: "test-repository",
+				Directories: []templatesv1.RepositoryGeneratorDirectoryItem{
+					{Path: "files/*"},
+				},
+			},
+			objects: []runtime.Object{newOCIRepository()},
+			wantErr: "no artifact for OCIRepository default/test-repository",
+		},
 	}
 
 	for _, tt := range testCases {


### PR DESCRIPTION
This fixes a bug when loading an empty GitRepository for the directories generation mechanism.

This fix is extended to OCI repositories.