### PR TITLE
Fix partial-apply resources bug

### DIFF
--- a/api/v1alpha1/conditions.go
+++ b/api/v1alpha1/conditions.go
@@ -17,7 +17,15 @@ const (
 )
 
 // SetGitOpsSetReadiness sets the ready condition with the given status, reason and message.
-func SetGitOpsSetReadiness(set *GitOpsSet, status metav1.ConditionStatus, reason, message string) {
+func SetGitOpsSetReadiness(set *GitOpsSet, inventory *ResourceInventory, status metav1.ConditionStatus, reason, message string) {
+	if inventory != nil {
+		set.Status.Inventory = inventory
+
+		if len(inventory.Entries) == 0 {
+			set.Status.Inventory = nil
+		}
+	}
+
 	set.Status.ObservedGeneration = set.ObjectMeta.Generation
 	newCondition := metav1.Condition{
 		Type:    meta.ReadyCondition,
@@ -26,18 +34,6 @@ func SetGitOpsSetReadiness(set *GitOpsSet, status metav1.ConditionStatus, reason
 		Message: message,
 	}
 	apimeta.SetStatusCondition(&set.Status.Conditions, newCondition)
-}
-
-// SetReadyWithInventory updates the GitOpsSet to reflect the new readiness and
-// store the current inventory.
-func SetReadyWithInventory(set *GitOpsSet, inventory *ResourceInventory, reason, message string) {
-	set.Status.Inventory = inventory
-
-	if len(inventory.Entries) == 0 {
-		set.Status.Inventory = nil
-	}
-
-	SetGitOpsSetReadiness(set, metav1.ConditionTrue, reason, message)
 }
 
 // GetGitOpsSetReadiness returns the readiness condition of the GitOpsSet.

--- a/controllers/gitopsset_controller_test.go
+++ b/controllers/gitopsset_controller_test.go
@@ -653,9 +653,7 @@ func TestReconciliation(t *testing.T) {
 		_, err = reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(gs)})
 		test.AssertErrorMatch(t, `update Resource: kustomizations.* is forbidden: User "system:serviceaccount:default:test-sa"`, err)
 
-		_, err = reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(gs)})
-		test.AssertErrorMatch(t, `update Resource: kustomizations.* is forbidden: User "system:serviceaccount:default:test-sa"`, err)
-
+		// Switch the permissions to allow updating.
 		var role rbacv1.Role
 		if err := k8sClient.Get(ctx, client.ObjectKey{Name: "test-role", Namespace: "default"}, &role); err != nil {
 			t.Fatal(err)

--- a/pkg/cmd/command.go
+++ b/pkg/cmd/command.go
@@ -95,12 +95,12 @@ func outputResources(out io.Writer, resources []*unstructured.Unstructured) erro
 func marshalOutput(out io.Writer, obj runtime.Object) error {
 	data, err := yaml.Marshal(obj)
 	if err != nil {
-		return fmt.Errorf("failed to marshal data: %v", err)
+		return fmt.Errorf("failed to marshal data: %w", err)
 	}
 
 	_, err = fmt.Fprintf(out, "%s", data)
 	if err != nil {
-		return fmt.Errorf("failed to write data: %v", err)
+		return fmt.Errorf("failed to write data: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
Previously, if an error occurred while reconciling, we returned immediately, this caused issues where the inventory could be lost in a partial apply case.