### PR TITLE
Fix the event type for error cases.

### DIFF
--- a/controllers/gitopsset_controller.go
+++ b/controllers/gitopsset_controller.go
@@ -76,9 +76,9 @@ func (r *GitOpsSetReconciler) event(obj *templatesv1.GitOpsSet, severity, msg st
 		reason = severity
 	}
 
-	eventType := "Normal"
+	eventType := corev1.EventTypeNormal
 	if severity == eventv1.EventSeverityError {
-		eventType = "Error"
+		eventType = corev1.EventTypeWarning
 	}
 
 	r.EventRecorder.Event(obj, eventType, reason, msg)

--- a/tests/e2e/gitopsset_controller_test.go
+++ b/tests/e2e/gitopsset_controller_test.go
@@ -1028,7 +1028,7 @@ func TestEventsWithFailingReconciling(t *testing.T) {
 		// reconciliation should fail because there is an existing resource.
 		want := []*test.EventData{
 			{
-				EventType: "Error",
+				EventType: corev1.EventTypeWarning,
 				Reason:    "ReconciliationFailed",
 			},
 		}


### PR DESCRIPTION


**What changed?**
This fixes the event type for error cases.

There's no Error type, the event types are corev1.EventTypeNormal and corev1.EventTypeWarning.

This was manifesting in the logs as an error saying that Error event types weren't supported.

- [ ] Has [Docs](https://github.com/weaveworks/gitopssets-controller/tree/main/docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps.
- [ ] Has Tests included if any functionality added or changed.
- [ ] Has an [Example](https://github.com/weaveworks/gitopssets-controller/tree/main/examples) if the change requires configuration to use.
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release.

For new Generators the above notes apply, with the following additional items:

- [ ] The Generator has been added to the Matrix generator's `GitOpsSetNestedGenerator`, this should be done by default unless there's some reason it doesn't work.
- [ ] The Generator has been added to the list of configurable [Generators](https://github.com/weaveworks/gitopssets-controller/blob/main/pkg/setup/generators.go), if you do not, the generator **cannot** be enabled!
- [ ] If the Generator depends on Kubernetes resources, a Watch has been added to track changes to the resources in the controller.

# Release Notes

```release-note
NONE
```
