### PR TITLE
Don't return no elements from an empty ImagePolicy.

### DIFF
--- a/controllers/templates/generators/imagepolicy/image_policy_test.go
+++ b/controllers/templates/generators/imagepolicy/image_policy_test.go
@@ -39,14 +39,6 @@ func TestGenerate(t *testing.T) {
 		want      []map[string]any
 	}{
 		{
-			"no policy image",
-			&templatesv1.ImagePolicyGenerator{
-				PolicyRef: "test-policy",
-			},
-			[]runtime.Object{test.NewImagePolicy()},
-			[]map[string]any{},
-		},
-		{
 			"image policy in status",
 			&templatesv1.ImagePolicyGenerator{
 				PolicyRef: "test-policy",
@@ -128,6 +120,15 @@ func TestGenerate_errors(t *testing.T) {
 		objects   []runtime.Object
 		wantErr   string
 	}{
+		{
+			"no policy image",
+			&templatesv1.ImagePolicyGenerator{
+				PolicyRef: "test-policy",
+			},
+			[]runtime.Object{test.NewImagePolicy()},
+			`no artifact for ImagePolicy default/test-policy`,
+		},
+
 		{
 			name: "missing image policy resource",
 			generator: &templatesv1.ImagePolicyGenerator{


### PR DESCRIPTION
**What changed?**
Fixes: #118

Handle an unpopulated ImagePolicy by not generating, which will prevent the removal of resources.

- [ ] Has [Docs](https://github.com/weaveworks/gitopssets-controller/tree/main/docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps.
- [ ] Has Tests included if any functionality added or changed.
- [ ] Has an [Example](https://github.com/weaveworks/gitopssets-controller/tree/main/examples) if the change requires configuration to use.
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings).
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release.

For new Generators the above notes apply, with the following additional items:

- [ ] The Generator has been added to the Matrix generator's `GitOpsSetNestedGenerator`, this should be done by default unless there's some reason it doesn't work.
- [ ] The Generator has been added to the list of configurable [Generators](https://github.com/weaveworks/gitopssets-controller/blob/main/pkg/setup/generators.go), if you do not, the generator **cannot** be enabled!
- [ ] If the Generator depends on Kubernetes resources, a Watch has been added to track changes to the resources in the controller.

# Release Notes

```release-note
NONE
```
